### PR TITLE
Preventing users from signing up with the username "follow" 

### DIFF
--- a/Chapter07/bookmarks/account/forms.py
+++ b/Chapter07/bookmarks/account/forms.py
@@ -3,6 +3,8 @@ from django.contrib.auth import get_user_model
 
 from .models import Profile
 
+User = get_user_model()
+
 
 class LoginForm(forms.Form):
     username = forms.CharField()
@@ -10,50 +12,46 @@ class LoginForm(forms.Form):
 
 
 class UserRegistrationForm(forms.ModelForm):
-    password = forms.CharField(
-        label='Password',
-        widget=forms.PasswordInput
-    )
-    password2 = forms.CharField(
-        label='Repeat password',
-        widget=forms.PasswordInput
-    )
+    password = forms.CharField(label="Password", widget=forms.PasswordInput)
+    password2 = forms.CharField(label="Repeat password", widget=forms.PasswordInput)
 
     class Meta:
-        model = get_user_model()
-        fields = ['username', 'first_name', 'email']
+        model = User
+        fields = ["username", "first_name", "email"]
 
     def clean_password2(self):
         cd = self.cleaned_data
-        if cd['password'] != cd['password2']:
+        if cd["password"] != cd["password2"]:
             raise forms.ValidationError("Passwords don't match.")
-        return cd['password2']
+        return cd["password2"]
+
+    def clean_username(self):
+        username = self.cleaned_data["username"]
+        if username.lower() == "follow":
+            raise forms.ValidationError("This username is not allowed.")
+        return username
 
     def clean_email(self):
-        data = self.cleaned_data['email']
+        data = self.cleaned_data["email"]
         if User.objects.filter(email=data).exists():
-            raise forms.ValidationError('Email already in use.')
+            raise forms.ValidationError("Email already in use.")
         return data
 
 
 class UserEditForm(forms.ModelForm):
     class Meta:
-        model = get_user_model()
-        fields = ['first_name', 'last_name', 'email']
+        model = User
+        fields = ["first_name", "last_name", "email"]
 
     def clean_email(self):
-        data = self.cleaned_data['email']
-        qs = User.objects.exclude(
-            id=self.instance.id
-        ).filter(
-            email=data
-        )
+        data = self.cleaned_data["email"]
+        qs = User.objects.exclude(id=self.instance.id).filter(email=data)
         if qs.exists():
-            raise forms.ValidationError('Email already in use.')
+            raise forms.ValidationError("Email already in use.")
         return data
 
 
 class ProfileEditForm(forms.ModelForm):
     class Meta:
         model = Profile
-        fields = ['date_of_birth', 'photo']
+        fields = ["date_of_birth", "photo"]


### PR DESCRIPTION
I added a `clean_username` method to the `UserRegistrationForm` in chapter 7, to ensure that users cannot create a username with 'follow' or different variant thereof. 

I also created a `User = get_user_model()` variable at the top of the file as in the original code `User` is not defined, which is mentioned in this issue #16.