### PR TITLE
fix(cart): ensure used coupons are removed from session after purchase

### DIFF
--- a/Chapter11/myshop/cart/cart.py
+++ b/Chapter11/myshop/cart/cart.py
@@ -73,6 +73,8 @@ class Cart:
     def clear(self):
         # remove cart from session
         del self.session[settings.CART_SESSION_ID]
+        # remove coupon_id from session
+        del self.session['coupon_id']
         self.save()
 
     def get_total_price(self):

--- a/Chapter11/myshop/cart/cart.py
+++ b/Chapter11/myshop/cart/cart.py
@@ -73,7 +73,8 @@ class Cart:
     def clear(self):
         # remove cart from session
         del self.session[settings.CART_SESSION_ID]
-        # remove coupon_id from session
+
+        # remove used coupon from session
         del self.session['coupon_id']
         self.save()
 


### PR DESCRIPTION
Resolved an issue where used coupons remained in the user's session after completing a purchase, causing them to be automatically applied in subsequent payments. This fix was implemented in the `clear` method of the cart module.